### PR TITLE
Update Appium.js - Issue #4047 - bstack:options'Prefix

### DIFF
--- a/lib/helper/Appium.js
+++ b/lib/helper/Appium.js
@@ -276,7 +276,7 @@ class Appium extends Webdriver {
     const _convertedCaps = {};
     for (const [key, value] of Object.entries(capabilities)) {
       if (!key.startsWith(vendorPrefix.appium)) {
-        if (key !== 'platformName') {
+        if (key !== 'platformName' && key !== 'bstack:options') {
           _convertedCaps[`${vendorPrefix.appium}:${key}`] = value;
         } else {
           _convertedCaps[`${key}`] = value;


### PR DESCRIPTION
- The 'bstack:options' key should not be prefixed with 'appium' as it may lead to improper execution of BrowserStack commands. The rationale behind this change is to ensure that the code block executes when the value of the variable key is neither 'platformName' nor 'bstack:options.' It's crucial to avoid prefixing 'appium' to 'bstack:options' as doing so might hinder the correct execution of BrowserStack commands.

- Resolves #4047 

Applicable helpers: Appium
Type of change: Bug fix

## Motivation/Description of the PR
- Description of this PR, which problem it solves
- Resolves #issueId (if applicable).

Applicable helpers:

- [ ] Playwright
- [ ] Puppeteer
- [ ] WebDriver
- [ ] REST
- [ ] FileHelper
- [ ] Appium
- [ ] TestCafe

Applicable plugins:

- [ ] allure
- [ ] autoDelay
- [ ] autoLogin
- [ ] customLocator
- [ ] pauseOnFail
- [ ] coverage
- [ ] retryFailedStep
- [ ] screenshotOnFail
- [ ] selenoid
- [ ] stepByStepReport
- [ ] stepTimeout
- [ ] wdio
- [ ] subtitles

## Type of change

- [ ] :fire: Breaking changes
- [ ] :rocket: New functionality
- [ ] :bug: Bug fix
- [ ] :clipboard: Documentation changes/updates
- [ ] :hotsprings: Hot fix
- [ ] :hammer: Markdown files fix - not related to source code
- [ ] :nail_care: Polish code

## Checklist:

- [ ] Tests have been added
- [ ] Documentation has been added (Run `npm run docs`)
- [ ] Lint checking (Run `npm run lint`)
- [ ] Local tests are passed (Run `npm test`)
